### PR TITLE
Add keystone support into admission container

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -232,6 +232,22 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/gophercloud/gophercloud"
+  packages = [
+    ".",
+    "openstack",
+    "openstack/identity/v2/tenants",
+    "openstack/identity/v2/tokens",
+    "openstack/identity/v3/tokens",
+    "openstack/networking/v2/networks",
+    "openstack/networking/v2/ports",
+    "openstack/utils",
+    "pagination"
+  ]
+  revision = "ef6628a63b53544b9c793f4c72925a1472436141"
+
+[[projects]]
+  branch = "master"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
@@ -396,7 +412,6 @@
     "internal/timeseries",
     "lex/httplex",
     "proxy",
-    "publicsuffix",
     "trace",
     "websocket"
   ]
@@ -487,12 +502,6 @@
   packages = ["."]
   revision = "a96e63847dc3c67d17befa69c303767e2f84e54f"
   version = "v2.1"
-
-[[projects]]
-  name = "gopkg.in/resty.v1"
-  packages = ["."]
-  revision = "f8815663de1e64d57cdd4ee9e2b2fa96977a030e"
-  version = "v1.4"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
@@ -833,6 +842,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e0f2f900386226d8bedc97fc2a87ed03383360380cc5d84e259d74ce7ce5772c"
+  inputs-digest = "f1af96a92894824f9bdd871c7a9c0c5f5b17361b611c8353cde944ee89bc22af"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,3 +21,7 @@
 [[constraint]]
   name = "github.com/kubevirt/device-plugin-manager"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/gophercloud/gophercloud"
+  branch = "master"

--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -18,7 +18,6 @@ func main() {
 
 	ah := &admission.AdmissionHook{}
 
-	flagset.StringVarP(&ah.ProviderURL, "provider-url", "", "", "URL of OVN manager (e.g. Neutron) API server")
 	flagset.StringVarP(&ah.ResourceNamespace, "resource-namespace", "", "", "Namespace for resources by Kubetron's Device Plugin")
 	flagset.StringVarP(&ah.ReservedMainResourceName, "reserved-main-resource-name", "", "", "Name of resource used for interface attachment handling, does not expose any specific resource, cannot be used for physnet names")
 	flagset.StringVarP(&ah.ReservedOverlayResourceName, "reserved-overlay-resource-name", "", "", "Name of resource used for exposing available overlay network, cannot be used for physnet names")

--- a/deploy/addon.yaml.in
+++ b/deploy/addon.yaml.in
@@ -143,7 +143,9 @@ items:
     name: config
     namespace: kubetron
   data:
-    providerURL: $PROVIDER_URL
+    providerAuthURL: $PROVIDER_KEYSTONE_URL
+    providerProjectName: $PROVIDER_PROJECT_NAME
+    providerDomainName: $PROVIDER_DOMAIN_NAME
     resourceNamespace: kubetron.network.kubevirt.io
     reservedMainResourceName: main
     reservedOverlayResourceName: overlay
@@ -199,7 +201,6 @@ items:
           args:
           - --tls-cert-file=/etc/certs/cert.pem
           - --tls-private-key-file=/etc/certs/key.pem
-          - --provider-url=$(PROVIDER_URL)
           - --resource-namespace=$(RESOURCE_NAMESPACE)
           - --reserved-main-resource-name=$(RESERVED_MAIN_RESOURCE_NAME)
           - --reserved-overlay-resource-name=$(RESERVED_OVERLAY_RESOURCE_NAME)
@@ -219,11 +220,31 @@ items:
               port: 443
             initialDelaySeconds: 10
           env:
-          - name: PROVIDER_URL
+          - name: OS_AUTH_URL
             valueFrom:
               configMapKeyRef:
                 name: config
-                key: providerURL
+                key: providerAuthURL
+          - name: OS_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: provider-secret
+                key: username
+          - name: OS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: provider-secret
+                key: password
+          - name: OS_PROJECT_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: providerProjectName
+          - name: OS_DOMAIN_NAME
+            valueFrom:
+              configMapKeyRef:
+                name: config
+                key: providerDomainName
           - name: RESOURCE_NAMESPACE
             valueFrom:
               configMapKeyRef:
@@ -346,3 +367,12 @@ items:
           - name: device-plugin
             hostPath:
               path: /var/lib/kubelet/device-plugins
+#Provider secrets
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: provider-secret
+    namespace: kubetron
+  data:
+    username: $PROVIDER_USERNAME
+    password: $PROVIDER_PASSWORD

--- a/hack/deploy-ovn-provider
+++ b/hack/deploy-ovn-provider
@@ -4,12 +4,14 @@ ssh -i id_rsa vagrant@192.168.200.11 "
 sudo yum install -y http://resources.ovirt.org/pub/yum-repo/ovirt-release-master.rpm ;
 sudo yum install -y ovirt-provider-ovn &&
 sudo bash -c 'cat <<EOF > /etc/ovirt-provider-ovn/conf.d/kubernetes.conf
+[PROVIDER]
+provider-host=192.168.200.11
 [SSL]
 https-enabled=false
 [OVN REMOTE]
 ovn-remote=tcp:127.0.0.1:6641
 [AUTH]
-auth-plugin=auth.plugins.static_token:NoAuthPlugin
+auth-plugin=auth.plugins.static_token:MagicTokenPlugin
 EOF' &&
 sudo systemctl restart ovirt-provider-ovn
 "

--- a/hack/install-addon
+++ b/hack/install-addon
@@ -30,7 +30,11 @@ done
 ADMISSION_CERT=$(cat server.crt | base64 -w 0)
 ADMISSION_KEY=$(cat hack/server-key.pem | base64 -w 0)
 KUBERNETES_CA=$(ssh -i id_rsa vagrant@192.168.200.11 "sudo cat /etc/kubernetes/ssl/ca.pem" | base64 -w 0)
-PROVIDER_URL=http://192.168.200.11:9696
+PROVIDER_KEYSTONE_URL=http://192.168.200.11:35357/v2.0/
+PROVIDER_PROJECT_NAME=admin
+PROVIDER_DOMAIN_NAME=kubetron
+PROVIDER_USERNAME=$(echo -n "admin" | base64)
+PROVIDER_PASSWORD=$(echo -n "pass" | base64)
 
 # batch request is not done sequentialy and sometimes it fails with "namespace does not exist",
 # therefore, create it beforehand
@@ -43,5 +47,9 @@ cat deploy/addon.yaml.in | \
     sed "s/\$ADMISSION_CERT/$ADMISSION_CERT/g" | \
     sed "s/\$ADMISSION_KEY/$ADMISSION_KEY/g" | \
     sed "s/\$KUBERNETES_CA/$KUBERNETES_CA/g" | \
-    sed "s#\$PROVIDER_URL#$PROVIDER_URL#g" | \
+    sed "s#\$PROVIDER_KEYSTONE_URL#$PROVIDER_KEYSTONE_URL#g" | \
+    sed "s#\$PROVIDER_PROJECT_NAME#$PROVIDER_PROJECT_NAME#g" | \
+    sed "s#\$PROVIDER_DOMAIN_NAME#$PROVIDER_DOMAIN_NAME#g" | \
+    sed "s#\$PROVIDER_USERNAME#$PROVIDER_USERNAME#g" | \
+    sed "s#\$PROVIDER_PASSWORD#$PROVIDER_PASSWORD#g" | \
     $KUBECTL apply -f -

--- a/hack/reinstall-addon
+++ b/hack/reinstall-addon
@@ -7,7 +7,11 @@ DEVICEPLUGIN_IMAGE=${DEVICEPLUGIN_IMAGE:-phoracek/kubetron-deviceplugin:latest}
 ADMISSION_CERT=$(cat server.crt | base64 -w 0)
 ADMISSION_KEY=$(cat hack/server-key.pem | base64 -w 0)
 KUBERNETES_CA=$(ssh -i id_rsa vagrant@192.168.200.11 "sudo cat /etc/kubernetes/ssl/ca.pem" | base64 -w 0)
-PROVIDER_URL=http://192.168.200.11:9696
+PROVIDER_KEYSTONE_URL=http://192.168.200.11:35357/v2.0/
+PROVIDER_PROJECT_NAME=admin
+PROVIDER_DOMAIN_NAME=kubetron
+PROVIDER_USERNAME=$(echo -n "admin" | base64)
+PROVIDER_PASSWORD=$(echo -n "pass" | base64)
 
 # batch request is not done sequentialy and sometimes it fails with "namespace does not exist",
 # therefore, create it beforehand
@@ -20,5 +24,9 @@ cat deploy/addon.yaml.in | \
     sed "s/\$ADMISSION_CERT/$ADMISSION_CERT/g" | \
     sed "s/\$ADMISSION_KEY/$ADMISSION_KEY/g" | \
     sed "s/\$KUBERNETES_CA/$KUBERNETES_CA/g" | \
-    sed "s#\$PROVIDER_URL#$PROVIDER_URL#g" | \
+    sed "s#\$PROVIDER_KEYSTONE_URL#$PROVIDER_KEYSTONE_URL#g" | \
+    sed "s#\$PROVIDER_PROJECT_NAME#$PROVIDER_PROJECT_NAME#g" | \
+    sed "s#\$PROVIDER_DOMAIN_NAME#$PROVIDER_DOMAIN_NAME#g" | \
+    sed "s#\$PROVIDER_USERNAME#$PROVIDER_USERNAME#g" | \
+    sed "s#\$PROVIDER_PASSWORD#$PROVIDER_PASSWORD#g" | \
     $KUBECTL apply -f -

--- a/pkg/admission/admission.go
+++ b/pkg/admission/admission.go
@@ -34,8 +34,6 @@ const (
 
 // AdmissionHook is implementation of generic-admission-server MutatingAdmissionHook interface
 type AdmissionHook struct {
-	// Full URL of OVN Manager (e.g. Neutron or oVirt OVN provider)
-	ProviderURL string
 	// Namespace of resources exposed by Kubetron's Device Plugin
 	ResourceNamespace string
 	// Name of the main resource exposed by Kubetron's Device Plugin
@@ -50,9 +48,6 @@ type AdmissionHook struct {
 
 // Initialize is called once when generic-addmission-server starts
 func (ah *AdmissionHook) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error {
-	if ah.ProviderURL == "" {
-		glog.Fatal(fmt.Errorf("Provider URL was not set"))
-	}
 	if ah.ResourceNamespace == "" {
 		glog.Fatal(fmt.Errorf("Resource namespace was not set"))
 	}
@@ -71,7 +66,11 @@ func (ah *AdmissionHook) Initialize(kubeClientConfig *restclient.Config, stopCh 
 	ah.client = client
 
 	// Initialize OVN Manager client
-	ah.providerClient = NewProviderClient(ah.ProviderURL)
+	ah.providerClient, err = NewProviderClient()
+	if err != nil {
+		return fmt.Errorf("failed to initialize Provider client: %v", err)
+	}
+	glog.V(2).Infof("Provider client created")
 
 	return nil
 }


### PR DESCRIPTION
Up to this point the network provider accepted any request to the api
without any authentication. Add support for the keystone. Use keystone
for every api call.

Signed-off-by: Ales Musil <amusil@redhat.com>